### PR TITLE
-Implemented method to derive the public ML-DSA key from the private key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 [Rr]elease/
 [Oo]bj/
 [Bb]in/
+BenchMarkDotNet.Artifacts/

--- a/PQnet.Test/PQApiRoundtripTests.cs
+++ b/PQnet.Test/PQApiRoundtripTests.cs
@@ -47,6 +47,7 @@ namespace PQnet.test {
 			ISignature signature;
 			byte[] private_key;
 			byte[] public_key;
+			byte[] derived_public_key;
 			byte[] signature_bytes;
 			byte[] message;
 			string error;
@@ -65,6 +66,10 @@ namespace PQnet.test {
 			Assert.IsNotNull(private_key, $"Private key is null for '{algorithm}' algorithm");
 			Assert.AreEqual(signature.PrivateKeyBytes, private_key.Length, $"Private key length is incorrect for '{algorithm}' algorithm");
 			Assert.AreEqual(signature.PublicKeyBytes, public_key.Length, $"Public key length is incorrect for '{algorithm}' algorithm");
+
+			success = signature.DerivePublicFromPrivateKey(private_key, out derived_public_key, out error);
+			Assert.IsTrue(success, $"Failed to derive public key from private key for '{algorithm}' algorithm: {error}");
+			CollectionAssert.AreEqual(public_key, derived_public_key, $"Derived public key does not match original public key for '{algorithm}' algorithm");
 
 			success = signature.Sign(message, private_key, null, out signature_bytes, out error);
 			Assert.IsTrue(success, $"Failed to sign message for '{algorithm}' algorithm: {error}");

--- a/PQnet/Common/ISignature.cs
+++ b/PQnet/Common/ISignature.cs
@@ -76,6 +76,15 @@ namespace PQnet {
 		bool GenerateKeyPair(out byte[] public_key, out byte[] private_key, byte[] seed, out string error);
 
 		/// <summary>
+		/// Derive the public key from a private key
+		/// </summary>
+		/// <param name="private_key">The private key</param>
+		/// <param name="public_key">Receives the public key</param>
+		/// <param name="error">Receives an error that occurred, or <c>null</c></param>
+		/// <returns><c>true</c> if the key was successfully returned, <c>false</c> otherwise</returns>
+		bool DerivePublicFromPrivateKey(byte[] private_key, out byte[] public_key, out string error);
+
+		/// <summary>
 		/// Generate a pure signature
 		/// </summary>
 		/// <param name="message">The message to sign</param>

--- a/PQnet/ML-DSA/MlDsaBase.cs
+++ b/PQnet/ML-DSA/MlDsaBase.cs
@@ -198,6 +198,26 @@ namespace PQnet {
 		}
 
 		/// <summary>
+		/// Derive the ML-DSA public key from a private key
+		/// </summary>
+		/// <param name="private_key">The private key</param>
+		/// <param name="public_key">Receives the public key</param>
+		/// <param name="error">Receives an error that occurred, or <c>null</c></param>
+		/// <returns><c>true</c> if the key was successfully returned, <c>false</c> otherwise</returns>
+		public bool DerivePublicFromPrivateKey(byte[] private_key, out byte[] public_key, out string error) {
+			if (private_key.Length != PrivateKeyBytes) {
+				public_key = null;
+				error = $"Private key must be {PrivateKeyBytes} bytes long";
+				return false;
+			}
+
+			ml_derive_public(private_key, out public_key);
+
+			error = null;
+			return true;
+		}
+
+		/// <summary>
 		/// Generate a pure ML-DSA signature
 		/// </summary>
 		/// <param name="message">The message to sign</param>

--- a/PQnet/ML-DSA/Sign.cs
+++ b/PQnet/ML-DSA/Sign.cs
@@ -119,6 +119,53 @@ namespace PQnet {
 			return true;
 		}
 
+		internal bool ml_derive_public(byte[] sk, out byte[] pk) {
+			byte[] tr;
+			byte[] rho;
+			byte[] key;
+			PolyVecL[] mat;
+			PolyVecL s1, s1hat;
+			PolyVecK s2, t1, t0;
+
+			mat = new PolyVecL[K];
+			for (int i = 0; i < K; i++) {
+				mat[i] = new PolyVecL(L, N);
+			}
+
+			rho = new byte[(2 * SeedBytes) + CrhBytes];
+			tr = new byte[TrBytes];
+			key = new byte[SeedBytes];
+			t0 = new PolyVecK(K, N);
+			s1 = new PolyVecL(L, N);
+			s2 = new PolyVecK(K, N);
+
+			/* unpack the private key */
+			unpack_sk(rho, tr, key, t0, s1, s2, sk);
+
+			/* Expand matrix */
+			polyvec_matrix_expand(mat, rho);
+
+			/* Matrix-vector multiplication */
+			t0 = new PolyVecK(K, N);
+			t1 = new PolyVecK(K, N);
+			s1hat = s1.Clone();
+			polyvecl_ntt(s1hat);
+			polyvec_matrix_pointwise_montgomery(t1, mat, s1hat);
+			polyveck_reduce(t1);
+			polyveck_invntt_tomont(t1);
+
+			/* Add error vector s2 */
+			polyveck_add(t1, t1, s2);
+
+			/* Extract t1 and write public key */
+			polyveck_caddq(t1);
+			polyveck_power2round(t1, t0, t1);
+			pk = new byte[PublicKeyBytes];
+			pack_pk(pk, rho, t1);
+
+			return true;
+		}
+
 		/*************************************************
 		* Name:        crypto_sign_signature_internal
 		*

--- a/PQnet/SLH-DSA/SlhDsaBase.Api.cs
+++ b/PQnet/SLH-DSA/SlhDsaBase.Api.cs
@@ -88,7 +88,7 @@ namespace PQnet {
 		}
 
 		/// <summary>
-		/// Derive an SLH-DSA public key from a private key
+		/// Derive the SLH-DSA public key from a private key
 		/// </summary>
 		/// <param name="private_key">The private key</param>
 		/// <param name="public_key">Receives the public key</param>

--- a/Sandcastle/PQnet.xml
+++ b/Sandcastle/PQnet.xml
@@ -156,6 +156,15 @@
             <param name="error">Receives any error that occurred, or <c>null</c></param>
             <returns><c>true</c> if the key pair was successfully generated, <c>false</c> otherwise</returns>
         </member>
+        <member name="M:PQnet.ISignature.DerivePublicFromPrivateKey(System.Byte[],System.Byte[]@,System.String@)">
+            <summary>
+            Derive the public key from a private key
+            </summary>
+            <param name="private_key">The private key</param>
+            <param name="public_key">Receives the public key</param>
+            <param name="error">Receives an error that occurred, or <c>null</c></param>
+            <returns><c>true</c> if the key was successfully returned, <c>false</c> otherwise</returns>
+        </member>
         <member name="M:PQnet.ISignature.Sign(System.Byte[],System.Byte[],System.Byte[]@)">
             <summary>
             Generate a pure signature
@@ -1076,6 +1085,15 @@
             <remarks>
             If <paramref name="seed"/> is provided, it must be exactly <see cref="F:PQnet.MlDsaBase.SeedBytes"/> bytes long.
             </remarks>
+        </member>
+        <member name="M:PQnet.MlDsaBase.DerivePublicFromPrivateKey(System.Byte[],System.Byte[]@,System.String@)">
+            <summary>
+            Derive the ML-DSA public key from a private key
+            </summary>
+            <param name="private_key">The private key</param>
+            <param name="public_key">Receives the public key</param>
+            <param name="error">Receives an error that occurred, or <c>null</c></param>
+            <returns><c>true</c> if the key was successfully returned, <c>false</c> otherwise</returns>
         </member>
         <member name="M:PQnet.MlDsaBase.Sign(System.Byte[],System.Byte[],System.Byte[]@)">
             <summary>
@@ -2166,7 +2184,7 @@
         </member>
         <member name="M:PQnet.SlhDsaBase.DerivePublicFromPrivateKey(System.Byte[],System.Byte[]@,System.String@)">
             <summary>
-            Derive an SLH-DSA public key from a private key
+            Derive the SLH-DSA public key from a private key
             </summary>
             <param name="private_key">The private key</param>
             <param name="public_key">Receives the public key</param>


### PR DESCRIPTION
- Added a method to extract the s1 and s2 vectors from the private key, calculate the matrix and then compute the public key
- Added DerivePublicFromPrivate to ISignature 
- Implemented public ML-DSA API to derive the public key
- Added test
